### PR TITLE
Fixing Israel DST ending date

### DIFF
--- a/c/hebcal.c
+++ b/c/hebcal.c
@@ -471,6 +471,11 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
           (todayHeb.dd >= 23 && todayHeb.dd <= 29) &&
           (todayHeb.mm != ELUL); /* no birkat hachodesh before rosh hashana */
       
+      // Set DST if we are using time based functions
+      if (print_sunrise_sunset || candle_today || molad_today)
+      {
+        set_DST (beginDST, endDST, todayAbs, &DST); 
+      }
       if (printHebDates_sw ||
           (printSomeHebDates_sw && 
            (holidays_today || sedra_today || omer_today || candle_today)))
@@ -540,7 +545,6 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
       /* Print CandleLighting times  */
       if (candle_today)
       {
-          set_DST (beginDST, endDST, todayAbs, &DST);
           print_candlelighting_times (returnedMask,
                                       day_of_week, todayGreg, DST);
       }


### PR DESCRIPTION
The israeli DST scheme wasn't right for this year, here is a fix, for the DST end. we have a while till the DST start, so I'll leave that for now

http://en.wikipedia.org/wiki/Israel_Summer_Time#2013.E2.80.93Present
