### PR TITLE
Zemanim, daf yomi, etc.

### DIFF
--- a/c/Makefile.am
+++ b/c/Makefile.am
@@ -21,7 +21,7 @@ bin_PROGRAMS = hebcal
 #sanity_check_SOURCES = common.c danlib.c error.c greg.c sanity-check.c
 
 hebcal_c_files = common.c danlib.c error.c mygetopt.c greg.c hebcal.c\
-         holidays.c rise.c sedra.c start.c gnu.c format.c
+         holidays.c rise.c sedra.c start.c gnu.c format.c dafyomi.c
 
 hebcal_h_files = common.h  danlib.h format.h greg.h hebcal.h \
           myerror.h mygetopt.h mymath.h mystdio.h mystring.h \

--- a/c/cities.h
+++ b/c/cities.h
@@ -47,10 +47,12 @@ city_t cities[] =
     {"Ottawa", 45, 42, 75, 71, -5, DST_USOFA},
     {"Panama City", 8, 58, 79, 32, -5, DST_NONE},
     {"Paris", 48, 52, -2, -20, 1, DST_EU},
+    {"Pawtucket RI",  41, 52, 71, 23,-5, DST_USOFA},
     {"Petach Tikvah", 32, 5, -34, -53, 2, DST_ISRAEL},
     {"Philadelphia", 39, 57, 75, 10, -5, DST_USOFA},
     {"Phoenix", 33, 27, 112, 4, -7, DST_NONE},
     {"Pittsburgh", 40, 26, 80, 0, -5, DST_USOFA},
+    {"Providence RI",  41, 50, 71, 23,-5, DST_USOFA},
     {"Saint Louis", 38, 38, 90, 12, -6, DST_USOFA},
     {"Saint Petersburg", 59, 53, -30, -15, 3, DST_EU},
     {"San Francisco", 37, 47, 122, 25, -8, DST_USOFA},
@@ -62,5 +64,6 @@ city_t cities[] =
     {"Vancouver", 49, 16, 123, 7, -8, DST_USOFA},
     {"White Plains",  41, 2, 73, 45, -5, DST_USOFA },
     {"Washington DC", 38, 55, 77, 0, -5, DST_USOFA},
+    {"Worcester MA",  42, 16, 71, 52,-5, DST_USOFA},
     {0, 0, 0, 0, 0, 0, 0}
 };

--- a/c/common.c
+++ b/c/common.c
@@ -30,6 +30,8 @@
 #include "greg.h"
 #include "hebcal.h"
 
+static long int hebrew_elapsed_days(int year);
+
 hmonths_t hMonths =
 {
     {
@@ -205,9 +207,9 @@ date_t abs2hebrew( long d )
 
     if( d >= 10555144L )
     {
-        fprintf(stderr, "parameter to abs2hebrew  %ld out of range\n", 
-                d );
-        exit(1);
+       char buf[40];
+       sprintf(buf, "%ld", d);
+       die("parameter to abs2hebrew %s out of range", buf);
     }
     
     gregdate = abs2greg (d);
@@ -241,9 +243,10 @@ date_t abs2hebrew( long d )
     day = (int) (d - hebrew2abs (hebdate) + 1L);
     if( day < 0)
     {
-        fprintf(stderr, "assertion failure d < hebrew2abs(m,d,y) => %ld < %ld!\n", 
+       char buf[100];
+       sprintf(buf, "assertion failure d < hebrew2abs(m,d,y) => %ld < %ld!\n", 
                 d, hebrew2abs(hebdate));
-        exit(1);
+       die(buf, NULL);
     }
 
     hebdate.dd = day;

--- a/c/dafyomi.c
+++ b/c/dafyomi.c
@@ -1,0 +1,163 @@
+/*
+   $Id: hebcal.c,v 1.9 2002/09/13 19:41:29 sadinoff Exp $
+   Hebcal - A Jewish Calendar Generator
+   Copyright (C) 1994  Danny Sadinoff
+   Portions Copyright (c) 2002 Michael J. Radwin. All Rights Reserved.
+
+   https://github.com/hebcal/hebcal
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+   This is the Hebcal daf yomi calculator,
+   adapted by Aaron Peromsik from Bob Newell's public domain daf.el.
+   more info: https://groups.google.com/forum/#!topic/comp.emacs/Gr-rijg2kgM
+*/
+
+#include <stdio.h>
+#include "hebcal.h"
+#include "mystring.h"
+
+#define NM_LEN 60
+
+struct mesechta {
+   char *sname;
+   char *aname;
+   char *hname;
+   int   blatt;
+};
+
+static struct mesechta shas[] = {
+  { "Berachot",       "Berachos",         "Berachos",       64      },
+  { "Shabbat",        "Shabbos",          "Shabbos",        157     },
+  { "Eruvin",         "Eruvin",           "Eruvin",         105     },
+  { "Pesachim",       "Pesachim",         "Pesachim",       121     },
+  { "Shekalim",       "Shekalim",         "Shekalim",       22      },
+  { "Yoma",           "Yoma",             "Yoma",           88      },
+  { "Sukkah",         "Sukkah",           "Sukkah",         56      },
+  { "Beitzah",        "Beitzah",          "Beitzah",        40      },
+  { "Rosh Hashana",   "Rosh Hashana",     "Rosh Hashana",   35      },
+  { "Taanit",         "Taanis",           "Taanis",         31      },
+  { "Megillah",       "Megillah",         "Megillah",       32      },
+  { "Moed Katan",     "Moed Katan",       "Moed Katan",     29      },
+  { "Chagigah",       "Chagigah",         "Chagigah",       27      },
+  { "Yevamot",        "Yevamos",          "Yevamos",        122     },
+  { "Ketubot",        "Kesubos",          "Kesubos",        112     },
+  { "Nedarim",        "Nedarim",          "Nedarim",        91      },
+  { "Nazir",          "Nazir",            "Nazir",          66      },
+  { "Sotah",          "Sotah",            "Sotah",          49      },
+  { "Gitin",          "Gitin",            "Gitin",          90      },
+  { "Kiddushin",      "Kiddushin",        "Kiddushin",      82      },
+  { "Baba Kamma",     "Baba Kamma",       "בבא קמא",        119     },
+  { "Baba Metzia",    "Baba Metzia",      "בבא מציעא"  ,    119     },
+  { "Baba Batra",     "Baba Basra",       "בבא בתרא"  ,     176     },
+  { "Sanhedrin",      "Sanhedrin",        "סנהדרין"  ,      113     },
+  { "Makkot",         "Makkos",           "מכות"  ,         24      },
+  { "Shevuot",        "Shevuos",          "שבועות" ,        49      },
+  { "Avodah Zarah",   "Avodah Zarah",     "עבודה זרה"   ,   76      },
+  { "Horayot",        "Horayos",          "הוריות" ,        14      },
+  { "Zevachim",       "Zevachim",         "זבחים",          120     },
+  { "Menachot",       "Menachos",         "Menachos",       110     },
+  { "Chullin",        "Chullin",          "Chullin",        142     },
+  { "Bechorot",       "Bechoros",         "Bechoros",       61      },
+  { "Arachin",        "Arachin",          "Arachin",        34      },
+  { "Temurah",        "Temurah",          "Temurah",        34      },
+  { "Keritot",        "Kerisos",          "Kerisos",        28      },
+  { "Meilah",         "Meilah",           "Meilah",         22      },
+  { "Kinnim",         "Kinnim",           "Kinnim",         4       },
+  { "Tamid",          "Tamid",            "Tamid",          10      },
+  { "Midot",          "Midos",            "Midos",          4       },
+  { "Niddah",         "Niddah",           "Niddah",         73      }
+};
+
+void hebcal_dafyomi( date_t *greg_day  )
+{
+   int dafcnt = 40;
+   int cno, dno, osday, nsday, total, count, j, cday, blatt;
+   date_t tmp_date;
+   char buffer[NM_LEN];
+
+   tmp_date.mm = 9;
+   tmp_date.dd = 11;
+   tmp_date.yy = 1923;
+   osday = greg2abs(tmp_date);
+   tmp_date.mm = 6;
+   tmp_date.dd = 24;
+   tmp_date.yy = 1975;
+   nsday = greg2abs(tmp_date);
+   cday = greg2abs(*greg_day);
+   
+   /*  No cycle, new cycle, old cycle */
+   if (cday < osday)
+      return; /* daf yomi hadn't started yet */
+   if (cday >= nsday)
+   {
+      cno = 8 + ( (cday - nsday) / 2711 );
+      dno = (cday - nsday) % 2711;
+   }
+   else
+   {
+      cno = 1 + ( (cday - osday) / 2702 );
+      dno = (cday - osday) / 2702;
+   }
+
+/* Find the daf taking note that the cycle changed slightly after cycle 7. */
+
+   total = blatt = 0;
+   count = -1;
+
+   /* Fix Shekalim for old cycles */
+   if (cno <= 7)
+      shas[4].blatt = 13;
+   else
+      shas[4].blatt = 22;
+
+   /* Find the daf */
+   j = 0;
+   while (j < dafcnt)
+   {
+      count++;
+      total = total + shas[j].blatt - 1;
+      if (dno < total)
+      {
+         blatt = (shas[j].blatt + 1) - (total - dno);
+         /* fiddle with the weird ones near the end */
+         switch(count)
+         {
+         case 36:
+            blatt = blatt + 21;
+            break;
+         case 37:
+            blatt = blatt + 24;
+            break;
+         case 38:
+            blatt = blatt + 33;
+            break;
+         default:
+            j = 1 + dafcnt;
+            break;
+         }
+      }
+      j ++;
+   }         
+
+   sprintf(buffer,
+           iso8859_8_sw ? "דף יומי: %s %d" : "Daf Yomi: %s %d",
+           iso8859_8_sw ? shas[count].hname :
+             ashkenazis_sw ? shas[count].aname : shas[count].sname,
+           blatt );
+   DeclareEvent( greg_day, NULL, buffer, 1 );
+}
+
+   

--- a/c/danlib.c
+++ b/c/danlib.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <ctype.h>
-#include <string.h>
+#include "mystring.h"
 #include <stdlib.h>
 #include "danlib.h"
 #include "myerror.h"
@@ -37,6 +37,12 @@ void initStr( char **s, size_t size )
     if ((*s = (char *) malloc ((size + 1) * sizeof (char))) == NULL)
         die ("\n Memory Error: Couldn't allocate string", "");
     **s = '\0';
+}
+
+void makeStr( char **s, char *src )
+{
+  initStr(s, strlen(src));
+  strcpy(*s, src);
 }
 
 /* istrncasecmp performs a signed, case-insensitive comparison

--- a/c/greg.c
+++ b/c/greg.c
@@ -26,7 +26,7 @@
 
 #include "mystdio.h"
 #include "danlib.h"
-#include <time.h>
+#include "mytime.h"
 #include <string.h>
 #include "myerror.h"
 #include "greg.h"
@@ -42,6 +42,12 @@ const char *eMonths[] =
     "UNUSED",
     "January", "February", "March", "April", "May", "June", "July",
     "August", "September", "October", "November", "December"
+};
+const char *shortMonthNames[] =
+{
+    "UNUSED",
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
+    "Aug", "Sep", "Oct", "Nov", "Dec"
 };
 
 int MonthLengths[][13] =

--- a/c/hebcal.c
+++ b/c/hebcal.c
@@ -25,7 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include "mystring.h"
 
 #include "hebcal.h"
 #include "common.h"
@@ -43,10 +43,15 @@
 int
   ashkenazis_sw, candleLighting_sw, euroDates_sw, hebrewDates_sw, inputFile_sw,
   israel_sw, latlong_sw, printOmer_sw, printMolad_sw, printSunriseSunset_sw, sedraAllWeek_sw, sedrot_sw, noGreg_sw,
+  shortGreg_sw,
   printHebDates_sw, printSomeHebDates_sw, noHolidays_sw, tabs_sw, weekday_sw,  suppress_rosh_chodesh_sw,
-  yearDigits_sw, yahrtzeitFile_sw, DST_scheme, DST_value;
+  sunsetAlways_sw, sunriseAlways_sw, dafYomi_sw,  
+  abbrev_sw, first_weekday, this_weekday,
+  yearDigits_sw, yahrtzeitFile_sw, DST_scheme, DST_value, default_zemanim;
 int iso8859_8_sw;
 long beginOmer, endOmer;
+int printf_sw = 1;
+extern hmonths_t hMonths;
 FILE *inFile, *yFile;
 char *formatString;
 extern holstorep_t holidays[14][MAXDAYS], union_Adar[MAXDAYS];
@@ -54,6 +59,9 @@ extern holstorep_t holidays[14][MAXDAYS], union_Adar[MAXDAYS];
 #define SIMCHAT_DAY 23
 int havdalah_minutes = 72;      /* default */
 int light_offset = -18;         /* outside jerusalem */
+
+extern const char *shortMonthNames[];
+
 
 /*-------------------------------------------------------------------------*/
 
@@ -146,8 +154,16 @@ void PrintGregDate( date_t dt )
             putchar (' ');
     }
     
+    if (shortGreg_sw)
+    {
     if (weekday_sw)
-        printf ("%s, ", ShortDayNames[dayOfWeek (dt)]);
+        printf ("%s ", ShortDayNames[dayOfWeek (dt)]);
+      printf("%d-%s: ", dt.dd, shortMonthNames[dt.mm]);
+    }
+    else if (weekday_sw)
+      printf ("%s, ", ShortDayNames[dayOfWeek (dt)]);
+
+    
 }
 
 /*-------------------------------------------------------------------------*/
@@ -313,11 +329,45 @@ set_DST( long beginDST, long endDST, long todayAbs, int *DST )
     }
 }
 
+static struct _zman {
+   int flags;
+   char *name_sfrd;
+   char *name_ashk;
+   double variable_hour;
+   int min_offset;
+} zemanim[] = {
+   { ZMAN_ALOT_HASHACHAR, "Alot HaShachar", "Alos HaShachar", 0, -72},
+   { ZMAN_MISHEYAKIR,     "Misheyakir", "Misheyakir", 0, -45},
+   { ZMAN_SUNRISE,        "Sunrise", "Sunrise", 0, 0, },
+   { ZMAN_SZKS,           "Kriat Shema, sof zeman", "Krias Shema, sof zeman", 3, 0 },
+   { ZMAN_TEFILAH,        "Tefilah, sof zeman", "Tefilah, sof zeman", 4, 0 }, 
+   { ZMAN_CHATZOT,        "Chatzot hayom", "Chatzos hayom", 6, 0 },
+   { ZMAN_MINCHA_GEDOLA,  "Mincha Gedolah", "Mincha Gedolah", 6.5, 0 },
+   { ZMAN_MINCHA_KETANA,  "Mincha Ketanah", "Mincha Ketanah", 9.5, 0 },
+   { ZMAN_PLAG_HAMINCHA,  "Plag HaMincha", "Plag HaMincha", 10.75, 0 },
+   { ZMAN_SUNSET,         "Sunset", "Sunset", 12, 0 },
+   { ZMAN_CANDLES_BEFORE,  "Light Candles Before", "Light Candles Before", 12, -18 },
+   { ZMAN_CANDLES_AFTER,   "Light Candles After", "Light Candles After", 12, 42 },
+   { ZMAN_TZAIT_42,        "Tzait HaKochavim", "Tzais HaKochavim", 12, 42 },
+   { ZMAN_TZAIT_72,        "Tzait HaKochavim", "Tzais HaKochavim", 12, 72 },
+   { ZMAN_HAVDALLAH,       "Havdallah after", "Havdallah after", 12, 42 }
+};
+
+/* mogen avraham: counts the 12 hrs from alos to 72 tzais. gra counts sunrise to sunset.
+ * would be nice to add last time for chametz on erev pesach and auto-select it on the right day.
+ * similarly for midnight on the seder nights.
+ * add flags for candles. how to choose between ma and gra? how to handle configurable havdalah and
+ * candlelighting?
+ *
+ * also need the iso8859 text back.
+ */
+
 /*-------------------------------------------------------------------------*/
 
 void print_sunrise_sunset(date_t todayGreg, int DST)
 {
     double xsunrise, xsunset;
+    htime_t adj_sunrise, adj_sunset;
     int day_adj, status;
     
     PrintGregDate (todayGreg);
@@ -328,83 +378,92 @@ void print_sunrise_sunset(date_t todayGreg, int DST)
         printf ("No sunset today.\n");
     else
     {
-        char * time_rise =timeadj ("", xsunrise, DST, &day_adj);
-        char * time_set =timeadj ("", xsunset, DST, &day_adj);
-        printf ("%s:%s; %s:%s\n",
+        timeadj (xsunrise, DST, &day_adj, &adj_sunrise);
+        timeadj (xsunset, DST, &day_adj, &adj_sunset);
+        printf ("%s: %2d:%02d; %s: %2d:%02d\n",
                 "Sunrise",
-                time_rise,
+                adj_sunrise.hours,
+                adj_sunrise.minutes,
                 "Sunset",
-                time_set
+                adj_sunset.hours,
+                adj_sunset.minutes
             );
-        free( time_rise );
-        free( time_set );
-        /*              printf("%s %s %.1lf\n",timeadj ("",xsunrise,0,&day_adj),
-                        timeadj ("",xsunset,0,&day_adj),
-                        (xsunset-xsunrise) * 5.0 + 120.0);
-        */
     }
 }
 
 void print_candlelighting_times( int mask, int weekday, date_t todayGreg, int DST)
 {
-    /* offset of sunset to candlelighting in minutes */
-    
-    if (weekday == FRI || (mask & LIGHT_CANDLES))
-    {
         double xsunrise, xsunset;
         int day_adj, status;
-        
-        PrintGregDate (todayGreg);
+    int sunsetExists, sunriseExists;
+    htime_t adj_time;
+    char buffer[80];
+    int num_zmanim = sizeof (zemanim) / sizeof (struct _zman); 
+    int i_zman;
+    double var_hr_hours = 0.0;
+    char *zman_name;
         
         status = suntime (&xsunrise, &xsunset, dayOfYear (todayGreg),
                         SUNRISE, SUNSET);
-        if (status & NO_SUNSET)
-            printf ("No sunset today.\n");
+    
+    if (!(status & NO_SUNRISE))
+        sunriseExists = TRUE;
         else
         {
-            char * time =timeadj ("", xsunset, light_offset + DST, &day_adj);
-            printf ("%s: %s\n",
-                    iso8859_8_sw ? "\344\343\354\367\372 \360\370\345\372" :
-                    "Candle lighting",
-                    time
-                );
-            free( time );
-            /*              printf("%s %s %.1lf\n",timeadj ("",xsunrise,0,&day_adj),
-                            timeadj ("",xsunset,0,&day_adj),
-                            (xsunset-xsunrise) * 5.0 + 120.0);
-            */
+       DeclareEvent( &todayGreg, NULL, "No sunrise today.", 0);
         }
+    
+    if (!(status & NO_SUNSET))
+        sunsetExists = TRUE;
+    else 
+    {
+       DeclareEvent( &todayGreg, NULL, "No sunset today.", 0);
     }
     
-    /* offset of sunset to havdallah in minutes */
-    if (weekday == SAT ||
-        ((mask & YOM_TOV_ENDS) &&
-        weekday != FRI))
+    if (sunsetExists && sunriseExists)
     {
-        double xsunrise, xsunset;
-        int day_adj, status;
+       double day_span = xsunset - xsunrise;
+       if (day_span < 0)
+          day_span += 24;
+       var_hr_hours = day_span / 12.0;
+    }
         
+    for (i_zman = 0; i_zman < num_zmanim; i_zman ++)
+    {
+       double var_hour;
+       double offset_from;
+       char *name;
       
-        PrintGregDate (todayGreg);
+       if ( (zemanim[i_zman].flags & mask) == 0 )
+          continue;
         
-        status = suntime (&xsunrise, &xsunset, dayOfYear (todayGreg),
-                          SUNRISE, SUNSET);
-        if (status & NO_SUNSET)
-            printf ("No sunset today.\n");
+       var_hour = zemanim[i_zman].variable_hour;
+       
+       if (var_hour < 12.0)
+       {
+          offset_from = xsunrise;
+          if (!sunriseExists)
+             continue;
+       }
         else
         {
-            char * time = timeadj ("",
-                                   xsunset,
-                                   havdalah_minutes + DST,
-                                   &day_adj);
-            printf ("%s (%d %s):%s\n",
-                    iso8859_8_sw ? "\344\341\343\354\344" : "Havdalah",
-                    havdalah_minutes,
-                    iso8859_8_sw ? "\343\367\345\372" : "min",
-                    time
-                    );
-            free( time );
+          offset_from = xsunset;
+          var_hour -= 12.0;
+          if (!sunsetExists)
+             continue;
         }
+          
+       timeadj( offset_from + (var_hour * var_hr_hours),
+                DST + zemanim[i_zman].min_offset,
+                &day_adj, &adj_time );
+       
+       // a bit heavy-handed, but without this days after 21-Dec 
+       // got the pm value wrong somehow.
+       adj_time.pm = (offset_from == xsunset);
+       
+       zman_name = ashkenazis_sw ? zemanim[i_zman].name_ashk :
+          zemanim[i_zman].name_sfrd;
+       DeclareEvent( &todayGreg, &adj_time, zman_name, 0 );
     }
 }
 
@@ -432,10 +491,18 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
     holstorep_t holi_start,holip;         /* a list of holidays for today */
     year_t theYear;
     char *omerStr ;
-    int omer, day_of_week, returnedMask, DST;
+    int omer, day_of_week, first_weekday, returnedMask, DST;
     int omer_today, sedra_today, candle_today, holidays_today, molad_today;
     molad_t moladNext;
     int monthNext;
+    int today_zemanim;
+    char buffer[80];
+    
+/* Used to decide whether a particular type of daily info should be
+   included in the abbreviated view. In abbreviated mode things like
+   sunrise, daf, omer are printed once a week. */
+#define INCLUDE_TODAY(_sw) \
+  ( (_sw) && ((!abbrev_sw) || (first_weekday == day_of_week)))
     
     todayHeb = abs2hebrew (todayAbs);
     todayGreg = abs2greg (todayAbs);
@@ -450,7 +517,7 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
     reset_Omer (todayHeb.yy);
     if (sedraAllWeek_sw || sedrot_sw)
         reset_sedra (todayHeb.yy);
-    day_of_week = (int) (todayAbs % 7L);
+    first_weekday = day_of_week = (int) (todayAbs % 7L);
     while (todayAbs <= endAbs)
     {
         /* get the holidays for today */
@@ -460,10 +527,6 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
       omer_today = printOmer_sw &&
           (todayAbs >= beginOmer) &&
           (todayAbs <= endOmer);
-      candle_today = candleLighting_sw &&
-          (day_of_week >= FRI ||
-           (returnedMask & LIGHT_CANDLES) ||
-           (returnedMask & YOM_TOV_ENDS));
       holidays_today = holip &&
         (!noHolidays_sw || (returnedMask & USER_EVENT));
       molad_today = printMolad_sw &&
@@ -471,21 +534,36 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
           (todayHeb.dd >= 23 && todayHeb.dd <= 29) &&
           (todayHeb.mm != ELUL); /* no birkat hachodesh before rosh hashana */
       
+      today_zemanim = 0;
+      if (INCLUDE_TODAY(default_zemanim))
+         today_zemanim |= default_zemanim;
+      if (INCLUDE_TODAY(sunsetAlways_sw))
+         today_zemanim |= ZMAN_SUNSET;
+      if (INCLUDE_TODAY(sunriseAlways_sw))
+         today_zemanim |= ZMAN_SUNRISE;
+      if (candleLighting_sw && (day_of_week == FRI || (returnedMask & LIGHT_CANDLES)))
+         today_zemanim |= ZMAN_CANDLES_BEFORE;
+      if (candleLighting_sw && (day_of_week == SAT || ((returnedMask & YOM_TOV_ENDS) && day_of_week != FRI)))
+         today_zemanim |= ZMAN_HAVDALLAH;
+      /* add ZMAN_CANDLES_AFTER for second day of yom tov */
+
       // Set DST if we are using time based functions
-      if (print_sunrise_sunset || candle_today || molad_today)
+      if (print_sunrise_sunset || today_zemanim || molad_today)
       {
         set_DST (beginDST, endDST, todayAbs, &DST); 
       }
-      if (printHebDates_sw ||
-          (printSomeHebDates_sw && 
-           (holidays_today || sedra_today || omer_today || candle_today)))
+      if (INCLUDE_TODAY(printHebDates_sw) ||
+          ((printSomeHebDates_sw || printHebDates_sw) && 
+           (holidays_today || sedra_today || omer_today || 
+            (today_zemanim & (ZMAN_CANDLES_BEFORE|ZMAN_CANDLES_AFTER|ZMAN_HAVDALLAH)))))
       {
-          PrintGregDate (todayGreg);
-          printf ("%d%s%s %s, %d\n", todayHeb.dd,       /* print the hebrew date */
+          sprintf (buffer, "%d%s%s %s, %d",
+                   todayHeb.dd,       /* print the hebrew date */
                   iso8859_8_sw ? "" : numSuffix( todayHeb.dd ),
                   iso8859_8_sw ? "" : " of",
                   LANGUAGE2(hMonths[LEAP_YR_HEB( todayHeb.yy )][todayHeb.mm].name),
                   todayHeb.yy);
+          DeclareEvent (&todayGreg, NULL, buffer, 0);
       }
       
       if (printSunriseSunset_sw)
@@ -496,14 +574,15 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
       /* print the sedra, if desired */
       if (sedra_today)
       {
-          const char *sedraStr = sedra( todayAbs );
-          if (NULL != sedraStr)
+          char sedraStr[40];
+          int foundSedra = sedra( todayAbs, sedraStr, 40 );
+          if (foundSedra)
           {
-              PrintGregDate( todayGreg );
-              printf( "%s %s\n",
+              sprintf(buffer, "%s %s",
                       iso8859_8_sw ? "\364\370\371\372" :
                       ashkenazis_sw ? "Parshas" : "Parashat",
                       sedraStr );
+              DeclareEvent( &todayGreg, NULL, buffer, 0 );
           }
       }
       
@@ -513,18 +592,15 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
       {
           if (!noHolidays_sw || (holip->typeMask & USER_EVENT))
           {
-/*              char buf[200];
-              puts(formatLine( todayGreg, todayHeb, holip->name, buf, 200));
-*/
-              PrintGregDate( todayGreg ); 
-              puts( holip->name ); 
+              DeclareEvent( &todayGreg, NULL, holip->name, 0 );
           }
       }
       
       /* Print the Omer */
-      if (omer_today)
+      if (INCLUDE_TODAY(omer_today))
       {
-          initStr (&omerStr, NM_LEN);
+          char omerStr[NM_LEN];
+          omerStr[0] = '\0';
           omer = (int) (todayAbs - beginOmer + 1L);
           if (!tabs_sw)
           {
@@ -537,15 +613,16 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
               strncat (omerStr, "Omer: ", NM_LEN);
               strncat (omerStr, hc_itoa (omer), NM_LEN);
           }
-          PrintGregDate (todayGreg);
-          printf ("%s\n", omerStr);
-          free( omerStr );
+          DeclareEvent( &todayGreg, NULL, omerStr, 0 );
       }
       
+      if (INCLUDE_TODAY(dafYomi_sw))
+         hebcal_dafyomi(&todayGreg);
+      
       /* Print CandleLighting times  */
-      if (candle_today)
+      if (today_zemanim)
       {
-          print_candlelighting_times (returnedMask,
+          print_candlelighting_times (today_zemanim,
                                       day_of_week, todayGreg, DST);
       }
       
@@ -574,10 +651,63 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
       }
       
 #     ifdef PLUG_LEAKS
-      free_holidays(*holip);
+      freeHolidays(&holi_start);
 #     endif
     }
+#undef INCLUDE_TODAY
 }
 
+#define MAX_EV 200
+HebcalEvent events[MAX_EV];
+int num_events = 0;
 
+void clean_events()
+{
+  int i;
+  for (i = 0; i < num_events; i ++)
+    if (events[i].desc != NULL)
+      {
+        free(events[i].desc);
+        events[i].desc = NULL;
+      }
+  num_events = 0;
+}
+
+void DeclareEvent(date_t *date, htime_t *time, char *description,
+                  int daf_flag)
+{
+
+  if (printf_sw)
+    {
+      PrintGregDate(*date);
+      printf("%s", description);
+      if (time)
+        {
+          printf (": %2d:%02d %s", time->hours, time->minutes,
+                      time->pm ? "pm": "am" );
+        }
+      printf("\n");
+    }
+  else
+    {
+      int i_ev = num_events;
+      if (i_ev == MAX_EV)
+        return;
+      num_events ++;
+      events[i_ev].mm = date->mm;
+      events[i_ev].dd = date->dd;
+      events[i_ev].yy = date->yy;
+      if (time == NULL)
+        {
+          events[i_ev].time.hours = 
+            events[i_ev].time.minutes = 
+            events[i_ev].time.pm = 
+            0;
+        }
+      else
+        events[i_ev].time = *time;
+      events[i_ev].daf_flag = daf_flag;
+      makeStr(&events[i_ev].desc, description);
+    }
+}
 

--- a/c/hebcal.c
+++ b/c/hebcal.c
@@ -495,7 +495,8 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
     int omer_today, sedra_today, candle_today, holidays_today, molad_today;
     molad_t moladNext;
     int monthNext;
-    int today_zemanim;
+    int today_zemanim, i_zman;
+    int num_zmanim = sizeof (zemanim) / sizeof (struct _zman); 
     char buffer[80];
     
 /* Used to decide whether a particular type of daily info should be
@@ -510,6 +511,14 @@ void main_calendar( long todayAbs, long endAbs) /* the range of the desired prin
     theYear = yearData (todayHeb.yy);
     set_DST_bounds (&beginDST, &endDST, todayGreg.yy);
     set_DST (beginDST, endDST, todayAbs, &DST);
+
+    /* plug in light_offset before starting the loop */
+    for (i_zman = 0; i_zman < num_zmanim; i_zman ++)
+      if (zemanim[i_zman].flags == ZMAN_CANDLES_BEFORE)
+        {
+          zemanim[i_zman].min_offset = light_offset;
+          break;
+        }
 
     /*============== Main Year Loop ==============*/
     

--- a/c/hebcal.h
+++ b/c/hebcal.h
@@ -48,6 +48,9 @@ extern int DST_scheme,
     ashkenazis_sw, 
     iso8859_8_sw,
     candleLighting_sw, 
+    sunriseAlways_sw,
+    sunsetAlways_sw,
+    dafYomi_sw,
     euroDates_sw,
     hebrewDates_sw,
     inputFile_sw,
@@ -62,12 +65,16 @@ extern int DST_scheme,
     sedraAllWeek_sw, 
     sedrot_sw, 
     noGreg_sw, 
+    shortGreg_sw,
     noHolidays_sw,
     suppress_rosh_chodesh_sw,
     tabs_sw,
     weekday_sw, 
+    abbrev_sw,
     yearDigits_sw,
-    yahrtzeitFile_sw;
+    yahrtzeitFile_sw,
+    printf_sw,
+   default_zemanim;
 
 extern int havdalah_minutes,
    light_offset;
@@ -110,6 +117,47 @@ typedef struct hsnode{  /* holiday storage structure */
     struct hsnode *next;
 } holstore_t, *holstorep_t;
 
+
+#define ZMAN_ALOT_HASHACHAR (1 <<  0)
+#define ZMAN_MISHEYAKIR     (1 <<  1)
+#define ZMAN_SUNRISE        (1 <<  2)
+#define ZMAN_SZKS           (1 <<  3)
+#define ZMAN_TEFILAH        (1 <<  4)
+#define ZMAN_CHATZOT        (1 <<  5)
+#define ZMAN_MINCHA_GEDOLA  (1 <<  6)
+#define ZMAN_MINCHA_KETANA  (1 <<  7)
+#define ZMAN_PLAG_HAMINCHA  (1 <<  8)
+#define ZMAN_SUNSET         (1 <<  9)
+#define ZMAN_CANDLES_BEFORE (1 << 10)
+#define ZMAN_CANDLES_AFTER  (1 << 11)
+#define ZMAN_TZAIT_42       (1 << 12)
+#define ZMAN_TZAIT_72       (1 << 13)
+#define ZMAN_HAVDALLAH      (1 << 14)
+
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+typedef struct htime {
+   int hours;
+   int minutes;
+   int pm;
+} htime_t;
+
+typedef struct hc_event {
+  int mm;
+  int dd;
+  int yy;
+  int daf_flag;
+  htime_t time;
+  char *desc;
+} HebcalEvent;
+
 year_t yearData( int );
 date_t nextHebDate( date_t );
 date_t prevHebDate( date_t );
@@ -123,7 +171,7 @@ void main_calendar( long,long );
 void print_candlelighting_times( int, int, date_t, int );
 void print_sunrise_sunset(date_t, int);
 void reset_Omer( int hYear );
-
+void DeclareEvent(date_t *, htime_t *, char *, int);
 extern const char * license[];
 extern const char * warranty[];
 #endif

--- a/c/holidays.c
+++ b/c/holidays.c
@@ -26,9 +26,8 @@
 
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
-
+#include "mystring.h"
 #include "myerror.h"
 #include "hebcal.h"
 #include "common.h"
@@ -36,6 +35,12 @@
 #include "rise.h"
 
 #define NM_LEN 60
+
+static void free_var_holidays(void);
+static void load_variable_holidays(int hYear);
+static void freeHoliday(holstorep_t holiday, int free_name);
+static void free_buckets(holstorep_t buckets[14 ][MAXDAYS ]);
+static void free_var_holidays(void);
 
 holstorep_t holidays[14][MAXDAYS], var_holidays[14][MAXDAYS];
 
@@ -435,7 +440,6 @@ static void load_variable_holidays( int hYear )
     PushHoliday (tmpholp, &var_holidays[TISHREI]
                  [roshHashana % 7L == THU ? 4 : 3]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_SHUVA;
     tempDt = abs2hebrew (day_on_or_before (SAT, 7L + roshHashana));
     PushHoliday (tmpholp, &var_holidays[TISHREI][tempDt.dd]);
@@ -444,85 +448,67 @@ static void load_variable_holidays( int hYear )
     /*    printf( "hyear is %d\n",hYear); */
     if (short_kislev (hYear))
     {
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_7_CANDLES;
         PushHoliday (tmpholp, &var_holidays[TEVET][1]);
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_8_CANDLES;
         PushHoliday (tmpholp, &var_holidays[TEVET][2]);
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_8TH_DAY;
         PushHoliday (tmpholp, &var_holidays[TEVET][3]);
     }
     else
     {
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_7_CANDLES;
         PushHoliday (tmpholp, &var_holidays[KISLEV][30]);
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_8_CANDLES;
         PushHoliday (tmpholp, &var_holidays[TEVET][1]);
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_CHANUKAH_8TH_DAY;
         PushHoliday (tmpholp, &var_holidays[TEVET][2]);
     }
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_SHEKALIM;
     tempDt = abs2hebrew (day_on_or_before (SAT, passover - 43L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_ZACHOR;
     tempDt = abs2hebrew (day_on_or_before (SAT, passover - 30L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_TA_ANIT_ESTHER;
     tempDt = abs2hebrew (passover - (passover % 7L == TUE ? 33L : 31));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
     if (LEAP_YR_HEB (hYear))
     {
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_PURIM_KATAN;
         PushHoliday (tmpholp, &var_holidays[ADAR_I][14]);
         
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_EREV_PURIM;
         PushHoliday (tmpholp, &var_holidays[ADAR_II][13]);
 
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_PURIM;
         PushHoliday (tmpholp, &var_holidays[ADAR_II][14]);
     }
     else
     {
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_EREV_PURIM;
         PushHoliday (tmpholp, &var_holidays[ADAR_I][13]);
 
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_PURIM;
         PushHoliday (tmpholp, &var_holidays[ADAR_I][14]);
     }
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHUSHAN_PURIM;
     tempDt = abs2hebrew (passover - (passover % 7L == SUN ? 28L : 29));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
 
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_PARAH;
     tempDt = abs2hebrew (day_on_or_before (SAT, passover - 14L) - 7L);
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_HACHODESH;
     tempDt = abs2hebrew (day_on_or_before (SAT, passover - 14L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_TA_ANIT_BECHOROT;
     if ((passover - 1L) % 7L == SAT)
     {   /* if the fast falls on Shabbat, move to Thursday */
@@ -533,7 +519,6 @@ static void load_variable_holidays( int hYear )
         PushHoliday (tmpholp, &var_holidays[NISAN][14]);
 
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_HAGADOL;
     tempDt = abs2hebrew (day_on_or_before (SAT, passover - 1L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
@@ -558,14 +543,12 @@ static void load_variable_holidays( int hYear )
         else if (nisan27 % 7L == SUN)
 	    nisan_day = 28;
 
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_YOM_HASHOAH;
         PushHoliday (tmpholp, &var_holidays[NISAN][nisan_day]);
     }
 
     if (hYear > 5708)
     {                            /* only really makes sense after 1948 */
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_YOM_HAZIKARON;
         if (passover % 7L == SUN)
             tempDt.dd = 3;
@@ -579,19 +562,16 @@ static void load_variable_holidays( int hYear )
             tempDt.dd = 5;
         PushHoliday (tmpholp, &var_holidays[IYYAR][tempDt.dd - 1]);
 
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_YOM_HAATZMA_UT;
         PushHoliday (tmpholp, &var_holidays[IYYAR][tempDt.dd]);
     }
 
     if (hYear > 5727)
     {                            /* only really makes sense after 1967 */
-        tmpholp = getHolstorep ();
         tmpholp->name = HOLIDAY_YOM_YERUSHALAYIM;
         PushHoliday (tmpholp, &var_holidays[IYYAR][28]);
     }
 
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_TZOM_TAMMUZ;
     if (tishaBav % 7L == SAT)
         tempDt = abs2hebrew (tishaBav - 20L);
@@ -599,27 +579,22 @@ static void load_variable_holidays( int hYear )
         tempDt = abs2hebrew (tishaBav - 21L);
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_CHAZON;
     tempDt = abs2hebrew (day_on_or_before (SAT, tishaBav));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_EREV_TISH_A_B_AV;
     PushHoliday (tmpholp, &var_holidays[AV]
                  [tishaBav % 7L == SAT ? 9 : 8]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_TISH_A_B_AV;
     PushHoliday (tmpholp, &var_holidays[AV]
                  [tishaBav % 7L == SAT ? 10 : 9]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_SHABBAT_NACHAMU;
     tempDt = abs2hebrew (day_on_or_before (SAT, tishaBav + 7L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
     
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_ASARA_B_TEVET;
     if (tevet10 % 7L == SAT)
         PushHoliday (tmpholp, &var_holidays[TEVET][11]);
@@ -629,10 +604,11 @@ static void load_variable_holidays( int hYear )
     tempDt.mm = TISHREI;
     tempDt.dd = 1;
     tempDt.yy = hYear + 1;
-    tmpholp = getHolstorep ();
     tmpholp->name = HOLIDAY_LEIL_SELICHOT;
     tempDt = abs2hebrew (day_on_or_before (SAT, hebrew2abs (tempDt) - 4L));
     PushHoliday (tmpholp, &var_holidays[tempDt.mm][tempDt.dd]);
+
+    free(tmpholp);
 }
 
 
@@ -705,7 +681,6 @@ void init_user_holidays( int hyear )
 
     }
 }
-
 
 /*-------------------------------------------------------------------------*/
 /* this function stores yahrtzeits found in yFile.
@@ -826,7 +801,6 @@ void init_yahrtzeits( int hyear )
 }
 
 
-
 /*-------------------------------------------------------------------------*/
 /** set up the stored holidays array. */
 void init_holidays( int hYear )
@@ -841,6 +815,7 @@ void init_holidays( int hYear )
 
     if (first)
     {
+        tmpholp = getHolstorep ();	/* allocate hsnode */
         for (m = 0, todayinp = inp_holidays;      /* load constant holidays */
              m < LAST_INDEX (inp_holidays);
              m++, todayinp++)
@@ -848,30 +823,17 @@ void init_holidays( int hYear )
 	    if (!(todayinp->typeMask & (IL_ONLY|CHUL_ONLY))
                 || ((todayinp->typeMask & IL_ONLY) && israel_sw)
                 || ((todayinp->typeMask & CHUL_ONLY) && !israel_sw)) {
-		tmpholp = getHolstorep ();	/* allocate hsnode */
 		tmpholp->typeMask = todayinp->typeMask;	/*load the new holiday */
 		tmpholp->name = LANGUAGE2(todayinp->name);
 		PushHoliday (tmpholp, &holidays[todayinp->date.mm][todayinp->date.dd]);
 	    }
         }
+        free(tmpholp);
         first = 0;
     }
     else
     {
-        for (m = 0; m <= 13; m++) /* clear variable holidays buckets */
-	{
-            for (d = 0; d <= 30; d++)
-            {
-                tmpholp = var_holidays[m][d];
-                while (tmpholp != NULL)
-                {
-                    tmpholp2 = tmpholp;
-                    tmpholp = tmpholp->next;
-                    free (tmpholp2);
-                }
-                var_holidays[m][d] = NULL;
-            }
-	}
+        free_var_holidays();
     }
 
     load_variable_holidays (hYear);
@@ -882,7 +844,44 @@ void init_holidays( int hYear )
         init_yahrtzeits (hYear);
 }
 
+static void freeHoliday(holstorep_t holiday, int free_name)
+{
+   if (free_name)
+      free(holiday->name);
+   free(holiday);
+}
 
+static void free_buckets(holstorep_t buckets[14][MAXDAYS])
+{
+   holstorep_t tmpholp, tmpholp2;
+   int m, d;
+        for (m = 0; m <= 13; m++) /* clear variable holidays buckets */
+	{
+            for (d = 0; d <= 30; d++)
+            {
+         tmpholp = buckets[m][d];
+                while (tmpholp != NULL)
+                {
+                    tmpholp2 = tmpholp;
+                    tmpholp = tmpholp->next;
+            freeHoliday(tmpholp2, TRUE);
+                }
+         buckets[m][d] = NULL;
+            }
+	}
+    }
+
+static void free_var_holidays() 
+{
+   free_buckets(var_holidays);
+}
+
+/*-------------------------------------------------------------------------*/
+void freeHolidayTables( )
+{
+   free_var_holidays();
+   free_buckets(holidays);
+}
 
 /*-------------------------------------------------------------------------*/
 void freeHolidays( holstorep_t *holiList )
@@ -891,8 +890,7 @@ void freeHolidays( holstorep_t *holiList )
     holstorep_t cur = *holiList;
     while( cur ) {
         next = cur->next;
-        free (cur->name);
-        free (cur);
+        freeHoliday(cur, TRUE);
         cur = next;
     }
     
@@ -936,6 +934,7 @@ int getHebHolidays( date_t dth, holstorep_t *holiList )
                      dth.yy);
             PushHoliday (tmpholip, &var_holidays[TISHREI][1]);
             tmpMask |= PushHoliday (tmpholip, holiList);
+            freeHoliday(tmpholip, TRUE);
         }
         else 
         {
@@ -957,6 +956,7 @@ int getHebHolidays( date_t dth, holstorep_t *holiList )
                     0;                       /* put your special output format here */
                 } /* don't name the rosh chodesh if -y switch */
                 tmpMask |= PushHoliday (tmpholip, holiList);
+                freeHoliday(tmpholip, TRUE);
             }
         }
     }
@@ -980,8 +980,8 @@ int getHebHolidays( date_t dth, holstorep_t *holiList )
             0;                     /* put your special output format here. */
         } /* don't name the rosh chodesh if -y switch */
         tmpMask |= PushHoliday (tmpholip, holiList);
+        freeHoliday(tmpholip, TRUE);
     }
     
-
     return tmpMask;
 }

--- a/c/mygetopt.c
+++ b/c/mygetopt.c
@@ -4,7 +4,7 @@
 /** NOTE: This is slated for destruction.  we're going to go to GNU-style args soon */
 
 
-#include <stdio.h>
+#include "mystdio.h"
 #include "mystring.h"
 
 #define ERR(S, C) if(Opterr){\

--- a/c/rise.h
+++ b/c/rise.h
@@ -21,8 +21,11 @@
 #define TWELVE 1
 #define TWENTYFOUR 0
 
+struct htime;
+typedef struct htime htime_t;
+
 int suntime(double *, double *, int, int, int);
 int one_time(int, double *, double, int, double, double, double);
-char *timeadj (char *, double, int, int *);
+void timeadj (double, int, int *, htime_t *);
 
 #endif

--- a/c/sedra.c
+++ b/c/sedra.c
@@ -35,14 +35,14 @@
  *
  */
 
-#include <string.h>
 
 #include "greg.h"
 #include "hebcal.h"
 #include "sedra.h"
 #include "common.h"
+#include "mystring.h"
 
-const char *sedrot[][3] =
+static const char *sedrot[][3] =
 {
     {"Bereshit",        "Bereshis",     "\341\370\340\371\351\372"},
     {"Noach",   "Noach",        "\360\347"},
@@ -72,7 +72,7 @@ const char *sedrot[][3] =
     {"Shmini",  "Shmini",       "\371\356\351\360\351"},
     {"Tazria",  "Sazria",       "\372\346\370\351\362"},
     {"Metzora", "Metzora",      "\356\366\370\362"},
-    {"Achrei Mot",      "Achrei Mos",   "\340\347\370\351 \356\345\372"},
+    {"Acharei Mot",      "Acharei Mos",   "\340\347\370\351 \356\345\372"},
     {"Kedoshim",        "Kedoshim",     "\367\343\371\351\355"},
     {"Emor",    "Emor", "\340\356\345\370"},
     {"Behar",   "Behar",        "\341\344\370"},
@@ -301,14 +301,15 @@ void reset_sedra( int hebYr ) /* the hebrew year */
 }
 
 
-/* returns a string "Parshat <parsha>" based on the current parsha number */
-/* NOTE-- the returned value lives in a static buffer. */
-char * sedra( long absDate )
+/* Fills input "buf" of size buf_len with a string "Parshat <parsha>"
+   based on the current parsha number, and returns 1; or returns 0 if
+   it can't find the parsha for some reason.
+ */
+int sedra( long absDate, char *buf, int buf_len )
 {
     
     int index;
     int weekNum;
-    static char buf[40];        /* FIX: eeeevill */
     
     /* find the first saturday on or after today's date */
     absDate = day_on_or_before (6, absDate + 6L);
@@ -329,9 +330,9 @@ char * sedra( long absDate )
     *buf = '\0';                        /* reset the return buffer */
     
     if (index >= 0)
-        strncpy (buf, LANGUAGE2(sedrot[index]), 40);
+        strncpy (buf, LANGUAGE2(sedrot[index]), buf_len);
     else if (-1 == index)
-        return NULL;
+        return 0;
     else
     {
         int i = U (index);      /* undouble the parsha */
@@ -339,5 +340,5 @@ char * sedra( long absDate )
                  LANGUAGE2(sedrot[i]),
                  LANGUAGE2(sedrot[i + 1]));
     }
-    return buf;
+    return 1;
 }

--- a/c/sedra.h
+++ b/c/sedra.h
@@ -4,7 +4,7 @@
 #ifndef __SEDRA__
 #define __SEDRA__
 
-char *sedra( long int absDate );
+int sedra( long int absDate, char *out_buf, int buf_len );
 void reset_sedra( int );
 
 #endif


### PR DESCRIPTION
This is most of what I had in my tree. I cleaned out the PalmOS stuff (good riddance) and some of the more blatantly Android-specific stuff (to be discussed later). Let me know if you need it further untangled into separate pull requests... but the merge/unmerge was looking kind of tricky.

I had added my own separate switches for sunrise/sunset. I have kept both those and the existing switch from the master branch, because both approaches might be useful in different contexts. When printing them along with other zemanim it seems to make more sense to show them in chronological order. Also my Android app intersperses calendar data with the events from Hebcal. 

The "DeclareEvent" function is there to collect events when compiled into another app, but I left it in this commit because it seems like a useful refactoring anyway, reducing some duplicated logic.

Daf Yomi has Hebrew names for only some of the mesechtot. I didn't wind up putting in more because the RTL handling was not working out right on Android in Hebrew mode. Of course it should be fixed at some point, along with Hebrew text for the names of the zemanim. 

Also added -W to have things like zemanim and daf show only once per week.
