### PR TITLE
Add foreign to automake parameters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ(2.57)
 AC_INIT(hebcal,3.15,hebcal-bugs@sadinoff.com)
 AC_CONFIG_SRCDIR([common.c])
 dnl #AM_INIT_AUTOMAKE([no-dependencies check-news])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AM_CONFIG_HEADER([config.h])
 
 # Checks for programs.


### PR DESCRIPTION
This makes the latest git code autoreconf-able on Mac, i.e. with this patch I can use `autoreconf -if; ./configure; make; ...` like I can do on the latests release (v3.15).

```
autoconf (GNU Autoconf) 2.69
automake (GNU automake) 1.14.1
```

Without the patch there is error:

```
$ autoreconf -fi
configure.ac:12: installing './compile'
Makefile.am: installing './INSTALL'
Makefile.am: error: required file './README' not found
Makefile.am: error: required file './ChangeLog' not found
parallel-tests: installing './test-driver'
autoreconf: automake failed with exit status: 1
```
