### PR TITLE
Fix the `numSuffix` calculation for numbers with more than 2 digits.

### DIFF
--- a/danlib.c
+++ b/danlib.c
@@ -84,12 +84,16 @@ int isAllNums ( const char *s )
   return (n == len);
 }
 
+static int tensDigit (int i)
+{
+    return (i % 100) / 10;
+}
 
-/* returns he proper ordinal suffix of a number */
+/* returns the proper ordinal suffix of a number */
 const char *
     numSuffix (int i)
 {
-    if ((i / 10) == 1)
+    if (tensDigit(i) == 1)
         return "th";
     switch (i % 10)
     {

--- a/danlib.h
+++ b/danlib.h
@@ -2,7 +2,7 @@
   See section COPYING for conditions for redistribution
 */
 #ifndef __DANLIB__
-#define __DANLIB
+#define __DANLIB__
 
 #include <stdio.h>
 


### PR DESCRIPTION
For numbers in the "teens" e.g. 13, this function would take a shortcut to return "th", but it did not correctly apply that same shortcut for numbers with more than 2 digits, e.g. 113, which would incorrectly return "rd".

Although the Omer never reaches triple digits, who knows where this function might be used in the future. Might as well fix it now.

Also fix the header guard to match the `#ifndef` check.