### PR TITLE
FIXED missing range check on MonthLengths array

### DIFF
--- a/greg.c
+++ b/greg.c
@@ -50,6 +50,15 @@ int MonthLengths[][13] =
     {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 };
 
+int getMonthLength(int year, int month)
+{
+    if (month < 0 || month > 13)
+    {
+        return 0;
+    }
+    return MonthLengths[LEAP (year)][month];
+}
+
 const char *ShortDayNames[] =
 {
     "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"

--- a/greg.h
+++ b/greg.h
@@ -39,6 +39,7 @@ typedef struct dateStruct {
     int yy;	/* years since year 1 BCE i.e. -1 = 2 BCE */
 } date_t;
 
+int getMonthLength(int year, int month);
 int dayOfYear( date_t );
 long greg2abs( date_t );
 date_t abs2greg(long);

--- a/holidays.c
+++ b/holidays.c
@@ -33,6 +33,7 @@
 #include "hebcal.h"
 #include "common.h"
 #include "danlib.h"
+#include "greg.h"
 
 #define _(String) lookup_translation(String)
 
@@ -775,7 +776,7 @@ void init_yahrtzeits( int hyear )
         sscanf (monthStr, "%d", &inMonth);
 
         if (inMonth > 12 || inMonth < 1 ||
-            inDay < 1 || inDay > MonthLengths[LEAP (inYear)][inMonth])
+            inDay < 1 || inDay > getMonthLength(inYear, inMonth))
         {
 
             warn ("Date out of range in yahrtzeit file. Skipping line %s",

--- a/start.c
+++ b/start.c
@@ -765,7 +765,7 @@ void handleArgs(int argc, char *argv[])
        {
 	   if (theMonth > 12)
                die("The month must be less than 13", "");
-	   if (theDay > MonthLengths[LEAP(theYear)][theMonth])
+	   if (theDay > getMonthLength(theYear, theMonth))
                die("Sorry, there aren't that many days in %s (then)",
                    eMonths[theMonth]);
 	}
@@ -861,7 +861,7 @@ int main(int argc, char* argv[])
         else
         {
             startAbs = greg2abs(tempDate);
-            tempDate.dd = MonthLengths[LEAP(theYear)][theMonth];
+            tempDate.dd = getMonthLength(theYear, theMonth);
             endAbs = greg2abs(tempDate);
         }
         break;


### PR DESCRIPTION
A missing range check on MonthLengths array caused strange results / crashes / infinite loop when running the app with wrong inputs.

For example on my laptop running:

```
$ ./hebcal 28 2018
```

Would enter an infinite loop

The added range check fixes the issue and treats invalid months as empty