### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ compiler:
 os:
   - linux
   - osx
+arch:
+ - amd64
+ - ppc64le  
 sudo: false
 # Change this to your needs
 script: aclocal && autoconf && automake --foreign --add-missing && ./configure && make all check


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
