### PR TITLE
Parameterize MANDIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY_NAME=hebcal
 MAN1_NAME=$(BINARY_NAME).1
 PREFIX=/usr/local
+MANDIR=/share/man
 
 all: $(BINARY_NAME) $(MAN1_NAME)
 
@@ -26,9 +27,10 @@ $(MAN1_NAME): $(MAN1_NAME).in version.go
 install: $(BINARY_NAME) $(MAN1_NAME)
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp $(BINARY_NAME) $(DESTDIR)$(PREFIX)/bin/$(BINARY_NAME)
-	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	cp $(MAN1_NAME) $(DESTDIR)$(PREFIX)/share/man/man1/$(MAN1_NAME)
+	mkdir -p $(DESTDIR)$(PREFIX)$(MANDIR)/man1
+	cp $(MAN1_NAME) $(DESTDIR)$(PREFIX)$(MANDIR)/man1/$(MAN1_NAME)
 
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/$(BINARY_NAME)
+

--- a/c/configure.ac
+++ b/c/configure.ac
@@ -39,6 +39,7 @@ AC_ARG_WITH([default-city],
      [AC_DEFINE_UNQUOTED(CITY,"$withval",[The Default City])],
      [AC_DEFINE(CITY,"New_York",[The Default City])])
 
+AC_CONFIG_FILES([hebcal.1])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([tests/Makefile])
 

--- a/c/configure.ac
+++ b/c/configure.ac
@@ -39,7 +39,6 @@ AC_ARG_WITH([default-city],
      [AC_DEFINE_UNQUOTED(CITY,"$withval",[The Default City])],
      [AC_DEFINE(CITY,"New_York",[The Default City])])
 
-AC_CONFIG_FILES([hebcal.1])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([tests/Makefile])
 


### PR DESCRIPTION
Make man page installation dir configurable from command line e.g. with `make MANDIR=/share/man`

Goal is to facilitate installation on systems that keep man pages in /usr/man or elsewhere.