### PR TITLE
Make DEFAULT_CITY a conditional assignment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY_NAME=hebcal
 MAN1_NAME=$(BINARY_NAME).1
 PREFIX=/usr/local
 MANDIR=/share/man
-DEFAULT_CITY="New York"
+DEFAULT_CITY?="New York"
 
 all: $(BINARY_NAME) $(MAN1_NAME)
 


### PR DESCRIPTION
Enables setting DEFAULT_CITY from command line at build time, as in:

DEFAULT_CITY=Baltimore make

