### PR TITLE
Add Slackbuild info

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Once you have those, you can prepare the build environment as follows:
 make clean all
 ```
 
+Slackware users can use the slackbuild at `https://slackbuilds.org/repository/15.0/office/hebcal/?search=hebcal`. If you have `sbotools` installed, it's simply: `sboinstall hebcal`.
+
 ## DISTRIBUTION
    Copyright (C) 1994-2011  Danny Sadinoff
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Once you have those, you can prepare the build environment as follows:
 make clean all
 ```
 
-Slackware users can use the slackbuild at `https://slackbuilds.org/repository/15.0/office/hebcal/?search=hebcal`. If you have `sbotools` installed, it's simply: `sboinstall hebcal`.
+Slackware users can use the slackbuild at https://slackbuilds.org/repository/15.0/office/hebcal/?search=hebcal. If you have `sbotools` installed, it's simply: `sboinstall hebcal`.
 
 ## DISTRIBUTION
    Copyright (C) 1994-2011  Danny Sadinoff


### PR DESCRIPTION
Slackbuilds are an easy way for Slackware users to install from source.

See: https://slackbuilds.org/repository/15.0/office/hebcal/?search=hebcal

The Slackbuild builds a package from source, which must be downloaded separately. A link to the github repo is provided.

PS I just submitted an updated Slackbuild for  v5.9.4 but it'll take a few days to show up on slackbuilds.org.

